### PR TITLE
Fix debug build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@ struct BipBuffer {
 impl BipBuffer {
     fn dbg_info(&self) -> String {
         format!(" read: {:?} -- write: {:?} -- last: {:?}  [len: {:?}] ",
-                self.read,
-                self.write,
-                self.last,
+                self.read.0,
+                self.write.0,
+                self.last.0,
                 self.len)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use cache_line_size::CacheAligned;
 
 struct BipBuffer {
-    sequestered: Box<std::any::Any>,
+    sequestered: Box<dyn std::any::Any>,
     buf: *mut u8,
     len: usize,
     read: CacheAligned<AtomicUsize>,


### PR DESCRIPTION
[CacheAligned](https://docs.rs/cache_line_size/1.0.0/cache_line_size/struct.CacheAligned.html) doesn't implement debug, which is causing some errors if the debug feature is enabled. Using the inner value works fine.